### PR TITLE
feat(UI): agregar componente botón minimalista con TailwindCSSagregar boton.astro minimalista según el issue asignado

### DIFF
--- a/src/components/UI/boton.astro
+++ b/src/components/UI/boton.astro
@@ -1,0 +1,28 @@
+---
+interface Props {
+  type?: "button" | "submit" | "reset";
+}
+
+const { type = "button" } = Astro.props;
+---
+
+<button
+  type={type}
+  class="
+    px-4 py-2
+    rounded-md
+    border border-slate-300
+    bg-white
+    text-slate-800 text-sm font-medium
+    shadow-sm
+    hover:bg-slate-50
+    transition
+    focus-visible:outline-none
+    focus-visible:ring-2
+    focus-visible:ring-slate-400
+    focus-visible:ring-offset-2
+    disabled:opacity-50 disabled:cursor-not-allowed
+  "
+>
+  <slot />
+</button>


### PR DESCRIPTION
Este Pull Request agrega un nuevo componente `boton.astro` dentro de la ruta
`src/components/UI/`, siguiendo las instrucciones del Issue #2 del proyecto
OculusLab Web.

Características del componente:
- Diseño minimalista usando TailwindCSS
- Componente reutilizable compatible con Astro
- Prop opcional `type` (button / submit / reset)
- Contenido interno manejado con <slot /> para permitir personalización

Este PR cumple con los criterios solicitados en el issue.
Quedo atento a cualquier sugerencia o comentario por parte de los mantenedores.
